### PR TITLE
Remove `enum-utils` as a dependency

### DIFF
--- a/vid_dup_finder_lib/Cargo.toml
+++ b/vid_dup_finder_lib/Cargo.toml
@@ -40,7 +40,6 @@ rustdct = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 ffmpeg_gst_wrapper = { path = "../ffmpeg_gst_wrapper", default-features = false, version = "0.4.0" }
-enum-utils = "0.1"
 cfg-if = "1.0"
 
 

--- a/vid_dup_finder_lib/src/definitions.rs
+++ b/vid_dup_finder_lib/src/definitions.rs
@@ -43,7 +43,7 @@ pub const HASH_BITS: u32 = HASH_SIZE.pow(3);
 pub const HASH_WORDS: u32 = HASH_BITS.div_ceil(usize::BITS);
 
 /// Algorithms to detect [black bars](https://en.wikipedia.org/wiki/Letterboxing_(filming))  around the edges of video frames
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, enum_utils::FromStr)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Cropdetect {
     /// Do not detect letterboxing
     None,
@@ -51,4 +51,16 @@ pub enum Cropdetect {
     Letterbox,
     /// Detect regions of videos that contain motion
     Motion,
+}
+
+impl std::str::FromStr for Cropdetect {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "None" => Ok(Cropdetect::None),
+            "Letterbox" => Ok(Cropdetect::Letterbox),
+            "Motion" => Ok(Cropdetect::Motion),
+            _ => Err(()),
+        }
+    }
 }


### PR DESCRIPTION
The [`enum-utils`](https://github.com/ecstatic-morse/enum-utils) crate is unmaintained and was used for only a trivial `impl FromStr`. It further depends on the `failure` crate, which is also unmaintained and has [soundness issues](https://rustsec.org/advisories/RUSTSEC-2019-0036.html). While the problematic parts were not actually being used, this change reduces noise in `cargo audit` output for any crates using this library.